### PR TITLE
Allow referencing component variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,11 @@ discovered by referencing it via
 ```
 
 The idea is to reference [fractal compound components](http://fractal.build/guide/components#compound-components)
-and the twig file inside the folder with the very same name.
+and the twig file inside the folder with the very same name. The same logic applies when you want to reference
+a variant: `@components/path/to/compound/component--variant`.
 
 Alternatively, the discovery via the Components Library module allows you to reference
 other files via `@components/path/to/file.twig` directly.
-
-## Todo
-
-- make variants available
 
 # History
 

--- a/src/Template/Loader/FractalCompoundHandlesLoader.php
+++ b/src/Template/Loader/FractalCompoundHandlesLoader.php
@@ -143,7 +143,8 @@ class FractalCompoundHandlesLoader extends Twig_Loader_Filesystem {
       $activeTheme->getPath(),
       reset($libs[$namespace]['paths']),
     ];
-    if (strpos($filename, '--') === FALSE) {
+
+    if (strpos($filename, self::VARIANT_DELIMITER) === FALSE) {
       $path[] = $componentName;
     }
     else {
@@ -151,8 +152,8 @@ class FractalCompoundHandlesLoader extends Twig_Loader_Filesystem {
       $variantParts = explode(self::VARIANT_DELIMITER, $filename);
       $path[] = $variantParts[0];      
     }
-    $path[] = $filename . self::TWIG_EXTENSION;
 
+    $path[] = $filename . self::TWIG_EXTENSION;
     $path = array_filter($path);
 
     return implode(DIRECTORY_SEPARATOR, $path);

--- a/src/Template/Loader/FractalCompoundHandlesLoader.php
+++ b/src/Template/Loader/FractalCompoundHandlesLoader.php
@@ -27,7 +27,6 @@ class FractalCompoundHandlesLoader extends Twig_Loader_Filesystem {
   }
 
   /**
-   *
    * Just return the default namespace with the name.
    *
    * @param $name
@@ -40,7 +39,6 @@ class FractalCompoundHandlesLoader extends Twig_Loader_Filesystem {
   }
 
   /**
-   *
    * Change the # handle to the template name.
    *
    * @param string $name
@@ -52,7 +50,6 @@ class FractalCompoundHandlesLoader extends Twig_Loader_Filesystem {
   }
 
   /**
-   *
    * Run exists with the correct template path.
    *
    * @param string $name
@@ -61,6 +58,20 @@ class FractalCompoundHandlesLoader extends Twig_Loader_Filesystem {
    */
   public function exists($name) {
     return parent::exists($this->convertToTwigPath($name));
+  }
+
+  /**
+   * Run isFresh with the correct template path.
+   * 
+   * @param string $name
+   *   The name of the template to check.
+   * @param int $time
+   *   The datetime int to check against.
+   * 
+   * @return bool
+   */
+  public function isFresh($name, $time) {
+    return parent::isFresh($this->convertToTwigPath($name), $time);
   }
 
   /**

--- a/src/Template/Loader/FractalCompoundHandlesLoader.php
+++ b/src/Template/Loader/FractalCompoundHandlesLoader.php
@@ -8,6 +8,7 @@ use Twig_Loader_Filesystem;
 class FractalCompoundHandlesLoader extends Twig_Loader_Filesystem {
 
   const TWIG_EXTENSION = '.twig';
+  const VARIANT_DELIMITER = '--';
 
   /**
    * @var ThemeManagerInterface
@@ -140,9 +141,17 @@ class FractalCompoundHandlesLoader extends Twig_Loader_Filesystem {
 
     $path = [
       $activeTheme->getPath(),
-      reset($libs[$namespace]['paths']) . $componentName,
-      $filename . self::TWIG_EXTENSION
+      reset($libs[$namespace]['paths']),
     ];
+    if (strpos($filename, '--') === FALSE) {
+      $path[] = $componentName;
+    }
+    else {
+      $path = array_merge($path, $subpaths);
+      $variantParts = explode(self::VARIANT_DELIMITER, $filename);
+      $path[] = $variantParts[0];      
+    }
+    $path[] = $filename . self::TWIG_EXTENSION;
 
     $path = array_filter($path);
 


### PR DESCRIPTION
The parent function 'isFresh' should also be using the correct path name.